### PR TITLE
CTA button isn't linked to setting location

### DIFF
--- a/snippets/block_cta.liquid
+++ b/snippets/block_cta.liquid
@@ -1,3 +1,3 @@
-<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'cta' | settings_id: section: section, block: block }}">
+<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'action' | settings_id: section: section, block: block }}">
   <a href="{{ block.settings.action }}" class="btn">{{ block.settings.text }}</a>
 </div>


### PR DESCRIPTION
<img width="1437" alt="Cornerstone Site - CTA button setting linkage" src="https://user-images.githubusercontent.com/17749903/54239444-7058c000-44d8-11e9-8419-45924406f97e.png">
