### PR TITLE
Optin form isn't linked to setting location

### DIFF
--- a/snippets/block_cta.liquid
+++ b/snippets/block_cta.liquid
@@ -1,3 +1,3 @@
-<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'cta' | settings_id: section: section, block: block }}">
+<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'action' | settings_id: section: section, block: block }}">
   <a href="{{ block.settings.action }}" class="btn">{{ block.settings.text }}</a>
 </div>

--- a/snippets/block_form.liquid
+++ b/snippets/block_form.liquid
@@ -1,5 +1,5 @@
 {% assign f = current_site.find_form[block.settings.form] %}
-<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'video' | settings_id: section: section, block: block }}">
+<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'form' | settings_id: section: section, block: block }}">
   {% form f %}
     {% for field in f.fields %}
       {{ field | form_input: label: true, placeholder: false }}


### PR DESCRIPTION
<img width="1437" alt="Cornerstone Site -Optin form setting linkage" src="https://user-images.githubusercontent.com/17749903/54239385-48695c80-44d8-11e9-9260-c74ec7f30429.png">
