### PR TITLE
Language text settings aren't linked to setting locations

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -3,7 +3,7 @@
   it clickable in the theme editor with a kjb-settings-id
 -->
 {% if section.settings.show_header %}
-  <div class="header">
+  <div class="header" kjb-settings-id="{{ 'logo' | settings_id: section: section }}">
     <div class="container">
       <div class="media align-middle">
         <a href="/">

--- a/snippets/block_cta.liquid
+++ b/snippets/block_cta.liquid
@@ -1,3 +1,3 @@
-<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'cta' | settings_id: section: section, block: block }}">
+<div class="{{ block.settings.width }}" kjb-settings-id="{{ 'action' | settings_id: section: section, block: block }}">
   <a href="{{ block.settings.action }}" class="btn">{{ block.settings.text }}</a>
 </div>


### PR DESCRIPTION
<img width="1463" alt="Cornerstone Site -Language setting linkage" src="https://user-images.githubusercontent.com/17749903/54239247-e1e43e80-44d7-11e9-80b0-0ddf907af947.png">
